### PR TITLE
Fix docker-compose UI entrypoint

### DIFF
--- a/docker/magentic-ui-browser-docker/entrypoint.sh
+++ b/docker/magentic-ui-browser-docker/entrypoint.sh
@@ -3,4 +3,9 @@ set -e
 
 umask 000
 
+if ! command -v magentic-ui >/dev/null 2>&1; then
+    echo "Installing Magentic-UI..."
+    pip install -e /workspace
+fi
+
 exec "$@"


### PR DESCRIPTION
## Summary
- ensure `magentic-ui` is available in the browser container by installing the package at runtime

## Testing
- `pytest -m "not npx" -q` *(fails: playwright import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888f71623f4833381e234a72ab17480