### PR TITLE
Set default browser container ports

### DIFF
--- a/docker/magentic-ui-browser-docker/Dockerfile
+++ b/docker/magentic-ui-browser-docker/Dockerfile
@@ -55,6 +55,8 @@ COPY openbox-rc.xml /root/.config/openbox/rc.xml
 EXPOSE 6080 37367
 
 ENV PLAYWRIGHT_WS_PATH="default"
+ENV NO_VNC_PORT=6080
+ENV PLAYWRIGHT_PORT=37367
 
 # Set the display environment variable
 ENV DISPLAY=:99

--- a/docker/magentic-ui-browser-docker/start.sh
+++ b/docker/magentic-ui-browser-docker/start.sh
@@ -4,5 +4,9 @@ set -e
 echo "Starting services..."
 echo "DISPLAY=$DISPLAY"
 
+# Ensure default ports are set if not provided at runtime
+NO_VNC_PORT=${NO_VNC_PORT:-6080}
+PLAYWRIGHT_PORT=${PLAYWRIGHT_PORT:-37367}
+
 # Start supervisord to manage all processes
 exec supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
## Summary
- define `NO_VNC_PORT` and `PLAYWRIGHT_PORT` defaults in the dockerfile
- fall back to these defaults in `start.sh`

## Testing
- `docker build -t test-image docker/magentic-ui-browser-docker` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688939053ff0833386824b551d73fa40